### PR TITLE
Get away from master/slave words

### DIFF
--- a/yaml-tools/yaml-tools/usr/bin/mk_cobbler.py
+++ b/yaml-tools/yaml-tools/usr/bin/mk_cobbler.py
@@ -48,21 +48,21 @@ def print_dl3x0_prod():
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=${ETH1_NAME} \\
   --mac=${MAC_ETH1} \\
-  --bonding=slave \\
-  --bonding-master=bond0
+  --bonding=subordinate \\
+  --bonding-main=bond0
 
 $COBBLER system edit \\
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=${ETH2_NAME} \\
   --mac=${MAC_ETH2} \\
-  --bonding=slave \\
-  --bonding-master=bond0
+  --bonding=subordinate \\
+  --bonding-main=bond0
 
 $COBBLER system edit \\
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=bond0 \\
   --mac=${MAC_ETH1} \\
-  --bonding=master \\
+  --bonding=main \\
   --bonding-opts="mode=1 primary=${ETH1_NAME} miimon=100" \\
   --static=1 \\
   --ip-address=${PROD_IP} \\
@@ -75,21 +75,21 @@ def print_dl3x0_cic():
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=${ETH3_NAME} \\
   --mac=${MAC_ETH3} \\
-  --bonding=slave \\
-  --bonding-master=bond1
+  --bonding=subordinate \\
+  --bonding-main=bond1
 
 $COBBLER system edit \\
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=${ETH4_NAME} \\
   --mac=${MAC_ETH4} \\
-  --bonding=slave \\
-  --bonding-master=bond1
+  --bonding=subordinate \\
+  --bonding-main=bond1
 
 $COBBLER system edit \\
   --name=${ORG}_${MACH}_${P}${NAME} \\
   --interface=bond1 \\
   --mac=${MAC_ETH3} \\
-  --bonding=master \\
+  --bonding=main \\
   --bonding-opts="mode=1 primary=${ETH3_NAME} miimon=100" \\
   --static=1 \\
   --ip-address=${CLUSTER_IP} \\

--- a/yaml-tools/yaml-tools/usr/bin/mk_zones_from_yaml.py
+++ b/yaml-tools/yaml-tools/usr/bin/mk_zones_from_yaml.py
@@ -94,7 +94,7 @@ def node_to_dns(y, d, z, nameserver):
 
 def write_custom_zone(z, fd):
   print >> fd, '''zone "%(zone)s." IN {
-  type master;
+  type main;
   file "%(zone)s.zone";
   notify yes;
   allow-transfer { any; };
@@ -106,7 +106,7 @@ def write_custom_arpa(a, fd):
   rev.reverse()
   rev = '.'.join(rev)
   print >> fd, '''zone "%(rev)s.in-addr.arpa." IN {
-  type master;
+  type main;
   file "%(arpa)s.in-addr.arpa";
   notify yes;
   allow-transfer { any; };
@@ -151,17 +151,17 @@ def write_zone_file(zone, fd):
       ; NN is the daily sequence number.
       ; After editing this file, always
       ; update this serial number to give
-      ; slaves a chance to keep
+      ; subordinates a chance to keep
       ; synchronized.
         %(refresh)s              ; refresh. The refresh interval
-      ; tells a slave for the zone how
+      ; tells a subordinate for the zone how
       ; often to check that the data for
       ; this zone is up to date.
-        %(retry)s             ; retry. If a slave fails to connect
-      ; to the master, it will retry in
+        %(retry)s             ; retry. If a subordinate fails to connect
+      ; to the main, it will retry in
       ; this amount of time. So here it is
       ; 15 minutes.
-        %(expiry)s              ; expiry. If a slave did not contact
+        %(expiry)s              ; expiry. If a subordinate did not contact
       ; the server for this amount of
       ; time, its records become useless,
       ; i.e. are expired.
@@ -193,17 +193,17 @@ def write_arpa_file(arpa, fd):
       ; NN is the daily sequence number.
       ; After editing this file, always
       ; update this serial number to give
-      ; slaves a chance to keep
+      ; subordinates a chance to keep
       ; synchronized.
         %(refresh)s              ; refresh. The refresh interval
-      ; tells a slave for the zone how
+      ; tells a subordinate for the zone how
       ; often to check that the data for
       ; this zone is up to date.
-        %(retry)s             ; retry. If a slave fails to connect
-      ; to the master, it will retry in
+        %(retry)s             ; retry. If a subordinate fails to connect
+      ; to the main, it will retry in
       ; this amount of time. So here it is
       ; 15 minutes.
-        %(expiry)s              ; expiry. If a slave did not contact
+        %(expiry)s              ; expiry. If a subordinate did not contact
       ; the server for this amount of
       ; time, its records become useless,
       ; i.e. are expired.


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.